### PR TITLE
Update testing.yml

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pylint
+          pip install pytest
           REQUIREMENTS_FILES=$(find . -name "requirements.txt")
           for file in $REQUIREMENTS_FILES; do
             directory=$(dirname $file)


### PR DESCRIPTION
The .yaml imports pylint instead of pytest. As a result, when pytest is called, then it is not found and an error is thrown.