### PR TITLE
fixed bug so extract.py extracts last 5 mins

### DIFF
--- a/pipeline/test_extract.py
+++ b/pipeline/test_extract.py
@@ -9,7 +9,8 @@ import pytest
 from requests.exceptions import Timeout, HTTPError
 
 from extract import (
-    unix_time_millis,
+    get_minute_rounded_down,
+    unix_time_seconds,
     load_sales_data,
     get_tags_from_url,
     get_title_from_url,
@@ -17,7 +18,7 @@ from extract import (
 )
 
 EXAMPLE_DATETIME = datetime(2023, 1, 1)
-EXAMPLE_UNIX_TIME = 1672531200000
+EXAMPLE_UNIX_TIME = 1672531200
 
 
 class TestBandcampAPI:
@@ -25,12 +26,13 @@ class TestBandcampAPI:
     Class used for testing base cases
     """
 
-    def test_unix_time_millis(self):
+    def test_unix_time_seconds(self):
         """
         Test whether the function returns the correct value
         """
-        result = unix_time_millis(EXAMPLE_DATETIME)
+        result = unix_time_seconds(EXAMPLE_DATETIME)
         assert result == EXAMPLE_UNIX_TIME
+        assert isinstance(result, int) is True
 
     @patch("extract.requests.get")
     def test_load_sales_data(self, mock_get):
@@ -101,6 +103,14 @@ class TestBandcampAPI:
             "image": "https://exampleimage.com"
         }]
         assert result == expected
+
+    def test_get_minute_rounded_down(self):
+        """
+        Test for base cases for func get_minute_rounded_down
+        """
+        dt = datetime(2024, 1, 5, 12, 34, 56, 789000)
+        expected_result = datetime(2024, 1, 5, 12, 34, 0, 0)
+        assert get_minute_rounded_down(dt) == expected_result
 
 
 class TestBandCampAPIFails:

--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -55,7 +55,7 @@ class TestTransform:
                 "amount_paid_usd": [10, 20], "artist": ["Artist1 ft. Artist2", "Artist2"]}
         df = pd.DataFrame(data)
 
-        cleaned_df = clean_dataframe(df)
+        cleaned_df = clean_dataframe(df, False)
 
         assert "tags" in cleaned_df.columns
         assert "title" in cleaned_df.columns


### PR DESCRIPTION
- Before extract.py extracted last 2 minutes. It's now changed so that it does last 5 minutes.
- This was because of the way the API was being called. A get request with the start_date parameter not equal to the minute exactly will by default extract only the last 2 mins.